### PR TITLE
Update readme to suupport tendermint's new version

### DIFF
--- a/tendermint/README.md
+++ b/tendermint/README.md
@@ -7,7 +7,7 @@ sudo apt install jq
 ## Problem: I don't know if my node is connected to the network
 When you add your node to the network, it will connect to a subset of nodes. To find out which ones, run:
 ```
-curl -s localhost:46657/net_info | jq ".result.peers[].node_info | {id, listen_addr, moniker}"
+curl -s localhost:26657/net_info | jq ".result.peers[].node_info | {id, listen_addr, moniker}"
 ```
 
 ## Problem: the network is stuck and does not accept new transactions
@@ -15,13 +15,13 @@ Maybe there are not enough pre-votes or pre-commits to reach consensus. This hap
 
 Run the command:
 ```
-curl -s localhost:46657/dump_consensus_state | jq ".result.round_state.votes"
+curl -s localhost:26657/dump_consensus_state | jq ".result.round_state.votes"
 ```
 You should see two keys: `prevotes` and `precommits`. The first stage to reach consensus is to vote (`prevote`) on the current round, the second stage is to commit (`precommit`) the block. The majority of the network needs to reach consensus on both steps to commit the block and move to the next one. If one (or both) of `prevotes` and `precommits` has less than ⅔ votes, the network is stuck and will wait for new nodes to come online and vote.
 
 Even if the network seems to not be responsive, transactions are stored in the mempool and put into the blockchain once the networ is able to reach consensus. You can check it by running:
 ```
-curl -s http://localhost:46657/num_unconfirmed_txs | jq .result
+curl -s http://localhost:26657/num_unconfirmed_txs | jq .result
 ```
 
 If this is the situation you are in, you need to talk to the other Members of the Network and make sure they come back online. To mitigate the issue in the future, make sure everyone is starting BigchainDB and Tendermint on boot of their machine. Also, a larger network can help.


### PR DESCRIPTION
The new release of tendermint has changed the default port from 46657 to 26657.